### PR TITLE
Fix API consumer header

### DIFF
--- a/src/create-api-handler.js
+++ b/src/create-api-handler.js
@@ -59,13 +59,13 @@ export default function createApiHandler({options}) {
      * @returns {Object}
      */
     function getRequestHeaders() {
+        const headers = {
+            'REB-API-CONSUMER': `RebillySDK/JS-SDK ${version}`
+        };
         if (options.apiKey) {
-            return {
-                'REB-APIKEY': options.apiKey,
-                'REB-API-CONSUMER': `RebillySDK/JS-SDK ${version}`
-            };
+            headers['REB-APIKEY'] = options.apiKey;
         }
-        return {};
+        return headers;
     }
 
     /**


### PR DESCRIPTION
Fix API consumer header after recent change. It was previously only enabled when a secret API key was used. This will insert the header even is a session token is present. 