### PR TITLE
Add request configuration to API objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ The Rebilly JS SDK library allows you to consume the Rebilly API using either No
 
 [![npm](https://img.shields.io/npm/v/rebilly-js-sdk.svg)](https://www.npmjs.com/package/rebilly-js-sdk)
 [![Build Status](https://travis-ci.org/Rebilly/rebilly-js-sdk.svg?branch=master)](https://travis-ci.org/Rebilly/rebilly-js-sdk)
-[![dependencies Status](https://david-dm.org/Rebilly/rebilly-js-sdk/status.svg)](https://david-dm.org/Rebilly/rebilly-js-sdk)
-[![devDependencies Status](https://david-dm.org/Rebilly/rebilly-js-sdk/dev-status.svg)](https://david-dm.org/Rebilly/rebilly-js-sdk?type=dev)
 [![Try rebilly-js-sdk on RunKit](https://badge.runkitcdn.com/rebilly-js-sdk.svg)](https://npm.runkit.com/rebilly-js-sdk)
 
 ### PCI Compliance Note

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,6 @@ The Rebilly JS SDK library allows you to consume the Rebilly API using either No
 
 [![npm](https://img.shields.io/npm/v/rebilly-js-sdk.svg)](https://www.npmjs.com/package/rebilly-js-sdk)
 [![Build Status](https://travis-ci.org/Rebilly/rebilly-js-sdk.svg?branch=master)](https://travis-ci.org/Rebilly/rebilly-js-sdk)
-[![dependencies Status](https://david-dm.org/Rebilly/rebilly-js-sdk/status.svg)](https://david-dm.org/Rebilly/rebilly-js-sdk)
-[![devDependencies Status](https://david-dm.org/Rebilly/rebilly-js-sdk/dev-status.svg)](https://david-dm.org/Rebilly/rebilly-js-sdk?type=dev)
 [![Try rebilly-js-sdk on RunKit](https://badge.runkitcdn.com/rebilly-js-sdk.svg)](https://npm.runkit.com/rebilly-js-sdk)
 
 ### PCI Compliance Note

--- a/docs/reference/types/collection.md
+++ b/docs/reference/types/collection.md
@@ -16,6 +16,7 @@ Each collection instance exposes the same properties.
 | offset | number | A zero-based index defining the starting position for the requested members. |
 | response | Object | The original response stripped down to the status code, status text and headers. Exposes three more properties: `{status, statusText, headers}`. |
 | getJSON | Function | Returns a plain mutable JSON object exposing the `items` of the current collection instance. Discards all other property. |
+| config | Object | An object literal with the original request query string parameters. |
 
 **Example**
 

--- a/docs/reference/types/file.md
+++ b/docs/reference/types/file.md
@@ -14,6 +14,7 @@ Each file instance exposes the same properties.
 | ---- | ---- | ----------- |
 | data | Object | An `arraybuffer` containing the file data returned by the request. |
 | response | Object | The original response stripped down to the status code, status text and headers. Exposes three more properties: `{status, statusText, headers}`. |
+| config | Object | An object literal with the original request query string parameters. |
 
 **Example**
 

--- a/docs/reference/types/member.md
+++ b/docs/reference/types/member.md
@@ -13,6 +13,7 @@ Each member instance exposes the same properties.
 | fields | Object | An object literal with key/value pairs for each field returned by the API in the response. |
 | response | Object | The original response stripped down to the status code, status text and headers. Exposes three more properties: `{status, statusText, headers}`. |
 | getJSON | Function | Returns a plain mutable JSON object exposing the `fields` of the current member instance. Discards the `response` property. |
+| config | Object | An object literal with the original request query string parameters. |
 
 **Example**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,7 +92,7 @@ pages:
       - Member: reference/types/member.md
       - Collection: reference/types/collection.md
       - File: reference/types/file.md
-  - Guides:
-    - Criteria: guides/criteria.md
-    - Filters: guides/filters.md
+#  - Guides:
+#    - Criteria: guides/criteria.md
+#    - Filters: guides/filters.md
   - License: license.md

--- a/src/collection.js
+++ b/src/collection.js
@@ -12,6 +12,7 @@ import deepFreeze from './deep-freeze';
  * @prop items {Array<Member>}
  * @prop response {Object}
  * @prop getJSON {Function: Object}
+ * @prop config {Object} original request configuration
  * @example
  * const api = RebillyAPI();
  * const customers = api.customers.getAll();
@@ -19,10 +20,11 @@ import deepFreeze from './deep-freeze';
  * const totalCount = customers.total;
  */
 export default class Collection {
-    constructor({data, status, statusText, headers}) {
+    constructor({data, status, statusText, headers}, config) {
         Object.keys(paginationHeaders).forEach(header => this[header] = Number(headers[paginationHeaders[header]]));
         this.response = {status, statusText, headers};
         this.items = data.map(member => new Member({data: member, status, statusText, headers}));
+        this.config = config;
         deepFreeze(this);
     }
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -20,8 +20,11 @@ import deepFreeze from './deep-freeze';
  * const totalCount = customers.total;
  */
 export default class Collection {
-    constructor({data, status, statusText, headers}, config) {
-        Object.keys(paginationHeaders).forEach(header => this[header] = Number(headers[paginationHeaders[header]]));
+    constructor({data, status, statusText, headers}, config = {}) {
+        Object.keys(paginationHeaders).forEach((header) => {
+            const value = headers[paginationHeaders[header]];
+            this[header] = value ? Number(value) : null;
+        });
         this.response = {status, statusText, headers};
         this.items = data.map(member => new Member({data: member, status, statusText, headers}));
         this.config = config;

--- a/src/create-api-handler.js
+++ b/src/create-api-handler.js
@@ -152,6 +152,7 @@ export default function createApiHandler({options}) {
      * @since 1.1.0
      * @param apiUser {string} your API user value found in Rebilly
      * @param apiKey {string} your secret API key found in Rebilly
+     * @deprecated
      * @returns {string}
      */
     function generateSignature({apiUser, apiKey}) {

--- a/src/file.js
+++ b/src/file.js
@@ -1,9 +1,13 @@
 /**
  * Simple structure for handling file payloads from the API.
+ * @prop response {Object}
+ * @prop data {ArrayBuffer}
+ * @prop config {Object} original request configuration
  */
 export default class File {
-    constructor({data, status, statusText, headers}) {
+    constructor({data, status, statusText, headers}, config) {
         this.response = {status, statusText, headers};
         this.data = data;
+        this.config = config;
     }
 }

--- a/src/file.js
+++ b/src/file.js
@@ -5,7 +5,7 @@
  * @prop config {Object} original request configuration
  */
 export default class File {
-    constructor({data, status, statusText, headers}, config) {
+    constructor({data, status, statusText, headers}, config = {}) {
         this.response = {status, statusText, headers};
         this.data = data;
         this.config = config;

--- a/src/member.js
+++ b/src/member.js
@@ -10,7 +10,7 @@ import deepFreeze from './deep-freeze';
  * @prop config {Object} original request configuration
  */
 export default class Member {
-    constructor({data, status, statusText, headers}, config) {
+    constructor({data, status, statusText, headers}, config = {}) {
         this.response = {status, statusText, headers};
         this.fields = {...data};
         this.config = config;

--- a/src/member.js
+++ b/src/member.js
@@ -7,11 +7,13 @@ import deepFreeze from './deep-freeze';
  * @prop response {Object}
  * @prop fields {Object}
  * @prop getJSON {Function: Object}
+ * @prop config {Object} original request configuration
  */
 export default class Member {
-    constructor({data, status, statusText, headers}) {
+    constructor({data, status, statusText, headers}, config) {
         this.response = {status, statusText, headers};
         this.fields = {...data};
+        this.config = config;
         deepFreeze(this);
     }
 


### PR DESCRIPTION
Add request configuration to API objects. This exposes the original query string parameters to the resulting Member, Collection or File returned by the SDK.