### PR TITLE
Temporarily fix deep-freeze issue with Firefox

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -1,6 +1,6 @@
 import Member from './member';
 import paginationHeaders from './pagination-headers';
-import deepFreeze from './deep-freeze';
+// import deepFreeze from './deep-freeze';
 
 /**
  * A collection of read-only entity members.
@@ -28,7 +28,7 @@ export default class Collection {
         this.response = {status, statusText, headers};
         this.items = data.map(member => new Member({data: member, status, statusText, headers}));
         this.config = config;
-        deepFreeze(this);
+        // deepFreeze(this);
     }
 
     /**

--- a/src/member.js
+++ b/src/member.js
@@ -1,4 +1,4 @@
-import deepFreeze from './deep-freeze';
+// import deepFreeze from './deep-freeze';
 
 /**
  * A single read-only entity member.
@@ -14,7 +14,8 @@ export default class Member {
         this.response = {status, statusText, headers};
         this.fields = {...data};
         this.config = config;
-        deepFreeze(this);
+        // temporary solution for Firefox
+        // deepFreeze(this);
     }
 
     /**


### PR DESCRIPTION
Temporarily fix deep-freeze issue with Firefox while we debug the underlying issue which seems to be related to Babel.