### PR TITLE
Fix cancelToken and deepFreeze conflict in Firefox

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -28,7 +28,7 @@ export default class Collection {
         this.response = {status, statusText, headers};
         this.items = data.map(member => new Member({data: member, status, statusText, headers}));
         this.config = config;
-        deepFreeze(this, {exclude: ['$cancelToken']});
+        deepFreeze(this, {exclude: ['cancelToken']});
     }
 
     /**

--- a/src/collection.js
+++ b/src/collection.js
@@ -1,6 +1,6 @@
 import Member from './member';
 import paginationHeaders from './pagination-headers';
-// import deepFreeze from './deep-freeze';
+import deepFreeze from './deep-freeze';
 
 /**
  * A collection of read-only entity members.
@@ -28,7 +28,7 @@ export default class Collection {
         this.response = {status, statusText, headers};
         this.items = data.map(member => new Member({data: member, status, statusText, headers}));
         this.config = config;
-        // deepFreeze(this);
+        deepFreeze(this, {exclude: ['$cancelToken']});
     }
 
     /**

--- a/src/create-api-handler.js
+++ b/src/create-api-handler.js
@@ -302,9 +302,9 @@ export default function createApiHandler({options}) {
      * @returns {Object}
      */
     function getRequestConfig(configuration = {}) {
-        let config = cleanUpParameters(configuration);
+        const config = cleanUpParameters(configuration);
         if (cancellationToken) {
-            config = {...config, $cancelToken: cancellationToken.token};
+            return {...config, cancelToken: cancellationToken.token};
         }
         return {...config};
     }

--- a/src/create-api-handler.js
+++ b/src/create-api-handler.js
@@ -139,6 +139,7 @@ export default function createApiHandler({options}) {
 
     /**
      * Returns a cancellation token for the active instance. Based on the withdrawn cancelable promises proposal.
+     * @deprecated 9.0.0
      * @returns {axios.CancelToken}
      */
     function getCancellationToken() {
@@ -303,9 +304,9 @@ export default function createApiHandler({options}) {
     function getRequestConfig(configuration = {}) {
         let config = cleanUpParameters(configuration);
         if (cancellationToken) {
-            config = {...config, cancelToken: cancellationToken.token};
+            config = {...config, $cancelToken: cancellationToken.token};
         }
-        return config;
+        return {...config};
     }
 
     /**

--- a/src/deep-freeze.js
+++ b/src/deep-freeze.js
@@ -14,7 +14,7 @@ export default function deepFreeze(obj, {exclude = []} = {}) {
             && !exclude.includes(prop)
             && (typeof obj[prop] === "object" || typeof obj[prop] === "function")
             && !Object.isFrozen(obj[prop])) {
-            deepFreeze(obj[prop]);
+            deepFreeze(obj[prop], {exclude});
         }
     });
 

--- a/src/deep-freeze.js
+++ b/src/deep-freeze.js
@@ -1,15 +1,17 @@
 /**
  * Deep freeze an object. Based on `substack/deep-freeze`.
  * @param obj {Object}
+ * @param exclude {Array}
  * @link https://github.com/substack/deep-freeze
  * @returns {Object}
  */
-export default function deepFreeze(obj) {
+export default function deepFreeze(obj, {exclude = []} = {}) {
     Object.freeze(obj);
     const isFunction = typeof obj === "function";
     Object.getOwnPropertyNames(obj).forEach((prop) => {
             if ((isFunction ? prop !== 'caller' && prop !== 'callee' && prop !== 'arguments' : true )
             && obj[prop] !== null
+            && !exclude.includes(prop)
             && (typeof obj[prop] === "object" || typeof obj[prop] === "function")
             && !Object.isFrozen(obj[prop])) {
             deepFreeze(obj[prop]);

--- a/src/member.js
+++ b/src/member.js
@@ -1,4 +1,4 @@
-// import deepFreeze from './deep-freeze';
+import deepFreeze from './deep-freeze';
 
 /**
  * A single read-only entity member.
@@ -14,8 +14,7 @@ export default class Member {
         this.response = {status, statusText, headers};
         this.fields = {...data};
         this.config = config;
-        // temporary solution for Firefox
-        // deepFreeze(this);
+        deepFreeze(this, {exclude: ['$cancelToken']});
     }
 
     /**

--- a/src/member.js
+++ b/src/member.js
@@ -14,7 +14,7 @@ export default class Member {
         this.response = {status, statusText, headers};
         this.fields = {...data};
         this.config = config;
-        deepFreeze(this, {exclude: ['$cancelToken']});
+        deepFreeze(this, {exclude: ['cancelToken']});
     }
 
     /**


### PR DESCRIPTION
Fix an issue encountered in Rebilly on a modern build stack where Firefox would trigger an error whenever the Member freezing logic tried to touch the Axios cancellation token.