### PR TITLE
Add invalid fields to error object from API response

### DIFF
--- a/src/errors/rebilly-error.js
+++ b/src/errors/rebilly-error.js
@@ -13,5 +13,6 @@ export default class RebillyError extends Error {
         this.status = response && response.status ? response.status : null;
         this.statusText = response && response.statusText ? response.statusText : null;
         this.details = response ? (response.data && response.data.details ? response.data.details : null ) : null;
+        this.invalidFields = response ? (response.data && response.data.invalidFields ? response.data.invalidFields : null ) : null;
     }
 }


### PR DESCRIPTION
Adds invalid fields to the error object from the API response. This exposes more information about which fields in the payload triggered validations errors on the API side.