### PR TITLE
Add close gateway account endpoint

### DIFF
--- a/docs/reference/resources/gateway-accounts.md
+++ b/docs/reference/resources/gateway-accounts.md
@@ -225,6 +225,27 @@ Type [`Member`][goto-member]
 
 See the [detailed API spec][7]{: target="_blank"} for all payload fields and response data.
 
+## close
+<div class="method"><code><strong>close</strong>({<span class="prop">id</span>}) -> <span class="return">{Member}</span></code></div>
+
+Permanently close or archive a gateway account by using its `id`. This cannot be undone.
+
+
+**Example**
+
+```js
+const gatewayAccount = await api.gatewayAccounts.close({id: 'foobar-001'});
+console.log(gatewayAccount.fields.status);
+```
+
+
+**Returns**
+
+A member exposing the gateway account fields.
+
+Type [`Member`][goto-member]
+
+
 
 ## getAllDowntimeSchedules
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "12.3.3",
+  "version": "12.4.0",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/src/resources/gateway-accounts-resource.js
+++ b/src/resources/gateway-accounts-resource.js
@@ -37,6 +37,10 @@ export default function GatewayAccountsResource({apiHandler}) {
             return apiHandler.post(`gateway-accounts/${id}/disable`);
         },
 
+        close({id}) {
+            return apiHandler.post(`gateway-accounts/${id}/close`);
+        },
+
         getAllDowntimeSchedules({id, limit = null, offset = null, filter = null} = {}) {
             const params = {
                 limit,


### PR DESCRIPTION
Add a close Gateway Account endpoint. Updated documentation. This will permanently close (archive) a Gateway Account.