### PR TITLE
Remove getAllMigratable method from PaymentCardsResource

### DIFF
--- a/docs/reference/rebilly-api.md
+++ b/docs/reference/rebilly-api.md
@@ -446,7 +446,7 @@ See Payment Instruments.
 ### Payment Cards Bank Names
 `:::js api.paymentCardsBankNames`
 
-All bank names related to all cards in transations. 
+All bank names related to all cards in transactions. 
 
 !!! info ""
     See the [**Payment Cards Bank Names resource**][23] for detailed method information.

--- a/docs/reference/resources/payment-cards-bank-names.md
+++ b/docs/reference/resources/payment-cards-bank-names.md
@@ -3,7 +3,7 @@
   
 > Member of [`RebillyAPI`][goto-rebillyapi]  
   
-All bank names related to all cards in transations.  
+All bank names related to all cards in transactions.  
   
   
   

--- a/docs/reference/resources/payment-cards.md
+++ b/docs/reference/resources/payment-cards.md
@@ -177,56 +177,6 @@ Type [`Member`][goto-member]
 
 See the [detailed API spec][5]{: target="_blank"} for all payload fields and response data.
 
-
-## getAllMigratable
-
-<div class="method">
-    <code>
-        <strong>getAllMigratable</strong>({
-        <span class="prop">limit</span><span class="optional" title="optional">opt</span>, 
-        <span class="prop">offset</span><span class="optional" title="optional">opt</span>, 
-        <span class="prop">sort</span><span class="optional" title="optional">opt</span>
-        <span class="prop">filter</span><span class="optional" title="optional">opt</span>
-        }) -> <span class="return">{Collection}</span>
-    </code>
-</div>
-
-Get a collection of migratable payment cards. Each entry will be a member.
-
-!!! info "Payment Card Migration"
-    Migrating payment cards lets you move cards in bulk from one gateway account to another. This is useful when the original gateway account is no longer available.
-
-**Example**
-
-```js
-// all parameters are optional
-const firstCollection = await api.paymentCards.getAllMigratable();
-
-// alternatively you can specify one or more of them
-const params = {limit: 20, offset: 100, sort: '-createdTime'}; 
-const secondCollection = await api.paymentCards.getAllMigratable(params);
-
-// access the collection items, each item is a Member
-secondCollection.items.forEach(paymentCard => console.log(paymentCard.fields.customerId));
-```
-
-**Parameters**
-
-
---8<----- "reference/resources/shared/filter-get-all.md"
-
-
-**Returns**
-
-A collection of migratable payment cards.
-
-Type [`Collection`][goto-collection]
-
-
-**API Spec**
-
-See the [detailed API spec][6]{: target="_blank"} for all payload fields and response data.
-
 ## migrate
 <div class="method"><code><strong>migrate</strong>({<span class="prop">data</span>}) -> <span class="return">{Member}</span></code></div>
 
@@ -261,7 +211,7 @@ Type [`Member`][goto-member]
 
 **API Spec**
 
-See the [detailed API spec][7]{: target="_blank"} for all payload fields and response data.
+See the [detailed API spec][6]{: target="_blank"} for all payload fields and response data.
 
 ## getAllMatchedRules
 <div class="method"><code><strong>getAllMatchedRules</strong>({<span class="prop">id</span>}) -> <span class="return">{Collection}</span></code></div>
@@ -292,5 +242,4 @@ Type [`Collection`][goto-collection]
 [3]: https://rebilly.github.io/RebillyAPI/#tag/Payment-Cards/paths/~1payment-cards/post
 [4]: https://rebilly.github.io/RebillyAPI/#tag/Payment-Cards/paths/~1payment-cards~1{id}~1authorization/post
 [5]: https://rebilly.github.io/RebillyAPI/#tag/Payment-Cards/paths/~1payment-cards~1{id}~1deactivation/post
-[6]: https://rebilly.github.io/RebillyUserAPI/#tag/Migrate-payment-cards/paths/~1payment-cards-migrations/get
-[7]: https://rebilly.github.io/RebillyUserAPI/#tag/Migrate-payment-cards/paths/~1payment-cards-migrations/post
+[6]: https://rebilly.github.io/RebillyUserAPI/#operation/migratePaymentCards

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "12.8.0",
+  "version": "13.0.0",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "12.7.0",
+  "version": "12.8.0",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/src/resources/payment-cards-resource.js
+++ b/src/resources/payment-cards-resource.js
@@ -35,16 +35,6 @@ export default function PaymentCardsResource({apiHandler}) {
             return apiHandler.post(`payment-cards/${id}/deactivation`);
         },
 
-        getAllMigratable({limit = null, offset = null, sort = null, filter = null} = {}) {
-            const params = {
-                limit,
-                offset,
-                sort,
-                filter
-            };
-            return apiHandler.getAll(`payment-cards-migrations`, params);
-        },
-
         migrate({data}) {
             return apiHandler.post(`payment-cards-migrations/migrate`, data);
         }

--- a/src/resources/payment-cards-resource.js
+++ b/src/resources/payment-cards-resource.js
@@ -36,7 +36,7 @@ export default function PaymentCardsResource({apiHandler}) {
         },
 
         migrate({data}) {
-            return apiHandler.post(`payment-cards-migrations/migrate`, data);
+            return apiHandler.post(`payment-cards-migrations`, data);
         }
     };
 };


### PR DESCRIPTION
We don't need this method as endpoint was removed
Use non BC endpoint for migrate payment cards