### PR TITLE
Update Credit Memo resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "13.0.0",
+  "version": "13.1.0",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/src/resources/credit-memos-resource.js
+++ b/src/resources/credit-memos-resource.js
@@ -12,5 +12,14 @@ export default function CreditMemosResource({apiHandler}) {
             };
             return apiHandler.getAll(`credit-memos`, params);
         },
+
+        get({id, expand = null}) {
+            const params = {expand};
+            return apiHandler.get(`credit-memos/${id}`, params);
+        },
+
+        getAllTransactions({id}) {
+            return apiHandler.getAll(`credit-memos/${id}/transactions`);
+        },
     };
 };


### PR DESCRIPTION
Adds two new methods to the Credit Memo resource:
- `get()` - for retrieving information related to a specific Credit Memo
- `getAllTransactions()` - for listing all transactions related to a specific Credit Memo