### PR TITLE
Update email setting verifications endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "15.3.10",
+  "version": "15.3.11",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/src/resources/email-delivery-settings-resource.js
+++ b/src/resources/email-delivery-settings-resource.js
@@ -52,7 +52,7 @@ export default function EmailDeliverySettingsResource({apiHandler}) {
          * @returns {Promise}
          */
         verify({token, data}) {
-            return apiHandler.patch(`verify/email-delivery-settings/${token}`, data);
+            return apiHandler.put(`email-delivery-setting-verifications/${token}`, data);
         },
 
     };


### PR DESCRIPTION
The endpoint was incorrect, this PR points it to the one as properly defined here:
https://rebilly.github.io/RebillyUserAPI/#operation/VerifyEmailDeliverySettings