### PR TITLE
Fix bug in emailDeliverySettings resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "15.3.12",
+  "version": "15.3.13",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/src/resources/email-delivery-settings-resource.js
+++ b/src/resources/email-delivery-settings-resource.js
@@ -44,7 +44,7 @@ export default function EmailDeliverySettingsResource({apiHandler}) {
          * @returns {Promise}
          */
         update({id, data}) {
-            return apiHandler.delete(`email-delivery-settings/${id}`, data);
+            return apiHandler.patch(`email-delivery-settings/${id}`, data);
         },
 
         /**


### PR DESCRIPTION
The `update` method was actually deleting `emailDeliverySettings`. This PR changes it to the correct HTTP verb.

https://rebilly.github.io/RebillyUserAPI/#operation/PatchEmailDeliverySettings