### PR TITLE
Add new cofiguration option 'urls'

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ const api = RebillyAPI({apiKey: 'secret-api-key', sandbox: true, timeout: 10000}
 | `timeout` | `integer` | Define the timeout in milliseconds for API requests. Defaults to `6000`.|
 | `version` | `string` | Define the version of the API to use. Defaults to `v2.1`. This configuration does not apply to `RebillyExperimentalAPI`. |
 | `organizationId` | `string` | Your organization identifier in scope of which need to perform request (if not specified, the default organization will be used). |
+| `urls` | `object` | Define the root urls for `live` and `sandbox` mode. Object must have a key for each mode that have strings for values. Defaults to `{live: 'https://api.rebilly.com', sandbox: 'https://api-sandbox.rebilly.com'}`|
 
 ### Collections and Members
 All resource calls except CSV or PDF downloads return either Members or Collections. Members are returned by all methods other than `getAll`, which returns a Collection. A collection contains a list of members. Both types are **immutable** (frozen) objects that can return a JSON representation of their member properties.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "17.0.1",
+  "version": "17.1.0",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/src/index.js
+++ b/src/index.js
@@ -17,16 +17,23 @@ const baseTimeoutMs = 6000;
  * @param sandbox {boolean} whether to use the sandbox endpoint or the live
  * @param timeout {number} timeout in milliseconds
  * @param organizationId {string} Organization identifier in scope of which need to perform request (if not specified, the default organization will be used)
+ * @param urls {object} which urls the sdk will use for the base url for live or sandbox modes
  * @returns {{account, apiKeys, bankAccounts, blacklists, checkoutPages, coupons, customers, customerAuthentication, customEvents, customFields, credentialHashes, disputes, events, files, gatewayAccounts, invoices, layouts, lists, notes, organizations, paymentCards, paymentCardsBankNames, paymentTokens, paypalAccounts, plans, previews, products, profile, search, segments, sessions, shippingZones, status, subscriptions, tracking, transactions, threeDSecure, users, webhooks, websites, addRequestInterceptor, removeRequestInterceptor, addResponseInterceptor, removeResponseInterceptor, setTimeout, setProxyAgent, setSessionToken, setEndpoints, getCancellationToken}}
  * @constructor
  */
-export default function RebillyAPI({apiKey = null, version = baseApiVersion, sandbox = false, timeout = baseTimeoutMs, organizationId = null} = {}) {
+export default function RebillyAPI({apiKey = null, version = baseApiVersion, sandbox = false, timeout = baseTimeoutMs, organizationId = null, urls = baseEndpoints} = {}) {
+    if(!urls.live || !urls.sandbox) {
+        throw new Error('RebillyAPI urls config must include a key for both `live` and `sandbox`');
+    }
+    if(typeof urls.live !== 'string' || typeof urls.sandbox !== 'string') {
+        throw new Error('RebillyAPI urls config `live` and `sandbox` must be strings');
+    }
     /**
      * Internal configuration options
-     * @type {{apiKey: string|null, apiVersion: string, isSandbox: boolean, requestTimeout: number, jwt: string|null}}
+     * @type {{apiEndpoints: {live: string, sandbox: string}, apiKey: string|null, apiVersion: string, isSandbox: boolean, requestTimeout: number, jwt: string|null}}
      */
     const options = {
-        apiEndpoints: baseEndpoints,
+        apiEndpoints: urls,
         apiKey: apiKey,
         apiVersion: version,
         isSandbox: sandbox,
@@ -45,16 +52,23 @@ export default function RebillyAPI({apiKey = null, version = baseApiVersion, san
  * @param sandbox {boolean} whether to use the sandbox endpoint or the live
  * @param timeout {number} timeout in milliseconds
  * @param organizationId {string} Organization identifier in scope of which need to perform request (if not specified, the default organization will be used)
+ * @param urls {object} which urls the sdk will use for the base url for live or sandbox modes
  * @returns {{histograms, reports, customers, setEndpoints, setTimeout}}
  * @constructor
  */
-function RebillyExperimentalAPI({apiKey = null, sandbox = false, timeout = baseTimeoutMs, organizationId = null} = {}) {
+function RebillyExperimentalAPI({apiKey = null, sandbox = false, timeout = baseTimeoutMs, organizationId = null, urls = baseEndpoints} = {}) {
+    if(!urls.live || !urls.sandbox) {
+        throw new Error('RebillyAPI urls config must include a key for both `live` and `sandbox`');
+    }
+    if(typeof urls.live !== 'string' || typeof urls.sandbox !== 'string') {
+        throw new Error('RebillyAPI urls config `live` and `sandbox` must be strings');
+    }
     /**
      * Internal configuration options
      * @type {{apiEndpoints: {live: string, sandbox: string}, apiKey: *, isSandbox: boolean, requestTimeout: number, jwt: null}}
      */
     const options = {
-        apiEndpoints: baseEndpoints,
+        apiEndpoints: urls,
         apiKey: apiKey,
         apiVersion: 'experimental',
         isSandbox: sandbox,


### PR DESCRIPTION
Enable a new option to define the root urls for `live` and `sandbox` mode.

Option must be an object with a key for each mode, that have strings for values. 

Defaults to `{live: 'https://api.rebilly.com', sandbox: 'https://api-sandbox.rebilly.com'}`