### PR TITLE
Remove params getall volumelimits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "19.1.1",
+  "version": "19.1.2",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/src/resources/gateway-accounts-resource.js
+++ b/src/resources/gateway-accounts-resource.js
@@ -67,7 +67,7 @@ export default function GatewayAccountsResource({apiHandler}) {
             return apiHandler.delete(`gateway-accounts/${id}/downtime-schedules/${downtimeScheduleId}`);
         },
 
-        getAllVolumeLimits() {
+        getAllVolumeLimits({id}) {
             return apiHandler.getAll(`gateway-accounts/${id}/limits`);
         },
 

--- a/src/resources/gateway-accounts-resource.js
+++ b/src/resources/gateway-accounts-resource.js
@@ -67,13 +67,8 @@ export default function GatewayAccountsResource({apiHandler}) {
             return apiHandler.delete(`gateway-accounts/${id}/downtime-schedules/${downtimeScheduleId}`);
         },
 
-        getAllVolumeLimits({id, limit = null, offset = null, filter = null} = {}) {
-            const params = {
-                limit,
-                offset,
-                filter,
-            };
-            return apiHandler.getAll(`gateway-accounts/${id}/limits`, params);
+        getAllVolumeLimits() {
+            return apiHandler.getAll(`gateway-accounts/${id}/limits`);
         },
 
         getVolumeLimit({id, volumeLimitId}) {


### PR DESCRIPTION
Removing limit, offset, filter from the `getAllVolumeLimits` method. API will not use this.