### PR TITLE
Add storefront purchase ready to pay endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "21.5.0",
+  "version": "21.5.1",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/src/resources/storefront/purchase-resource.js
+++ b/src/resources/storefront/purchase-resource.js
@@ -7,5 +7,9 @@ export default function PurchaseResource({apiHandler}) {
     preview({data = {}} = {}) {
       return apiHandler.post(`preview-purchase`, data);
     },
+
+    readyToPay({data = {}} = {}) {
+      return apiHandler.post(`ready-to-pay`, data);
+    },
   };
 };


### PR DESCRIPTION
Add new storefront endpoint. Within storefront purchase resource add a new endpoint for `storefront/v1/ready-to-pay`.
 API documentation for this endpoint [can be found here](https://storefront-api-docs.rebilly.com/#operation/StorefrontPostReadyToPay).