### PR TITLE
Rename id by token in GetToken operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "28.1.0",
+  "version": "29.0.0",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/src/resources/payment-tokens-resource.js
+++ b/src/resources/payment-tokens-resource.js
@@ -8,8 +8,8 @@ export default function PaymentTokensResource({apiHandler}) {
             return apiHandler.getAll(`tokens`, params);
         },
 
-        get({id}) {
-            return apiHandler.get(`tokens/${id}`);
+        get({token}) {
+            return apiHandler.get(`tokens/${token}`);
         },
 
         create({data}) {


### PR DESCRIPTION
We were using a named parameter `id` instead of token for the `GetToken` operation. 
