### PR TITLE
Rename customer merge parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "28.1.0",
+  "version": "29.0.0",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "29.0.0",
+  "version": "30.0.0",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/src/resources/customers-resource.js
+++ b/src/resources/customers-resource.js
@@ -45,8 +45,8 @@ export default function CustomersResource({apiHandler}) {
             return apiHandler.put(`customers/${id}`, data, params);
         },
 
-        merge({id, targetId = ''}) {
-            return apiHandler.delete(`customers/${id}?targetCustomerId=${targetId}`);
+        merge({id, targetCustomerId = ''}) {
+            return apiHandler.delete(`customers/${id}?targetCustomerId=${targetCustomerId}`);
         },
 
         getLeadSource({id}) {

--- a/src/resources/payment-tokens-resource.js
+++ b/src/resources/payment-tokens-resource.js
@@ -8,8 +8,8 @@ export default function PaymentTokensResource({apiHandler}) {
             return apiHandler.getAll(`tokens`, params);
         },
 
-        get({id}) {
-            return apiHandler.get(`tokens/${id}`);
+        get({token}) {
+            return apiHandler.get(`tokens/${token}`);
         },
 
         create({data}) {


### PR DESCRIPTION
Renaming parameter from `targetId` to  `targetCustomerId` to match with the name used in the openAPI spec. 

This is the name that will be used by the future auto code generator. 