### PR TITLE
Remove explicit data payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "30.1.0",
+  "version": "31.0.0",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/src/resources/invoices-resource.js
+++ b/src/resources/invoices-resource.js
@@ -129,7 +129,7 @@ export default function InvoicesResource({apiHandler}) {
             return apiHandler.getAll(`invoices/${id}/transaction-allocations`, params);
         },
         
-        applyTransaction({ id, data }) {
+        applyTransaction({id, data}) {
             return apiHandler.post(`invoices/${id}/transaction`, data);
         },
     };

--- a/src/resources/invoices-resource.js
+++ b/src/resources/invoices-resource.js
@@ -128,12 +128,8 @@ export default function InvoicesResource({apiHandler}) {
 
             return apiHandler.getAll(`invoices/${id}/transaction-allocations`, params);
         },
-
-        applyTransaction({id, transactionId, amount = null}) {
-            const data = {
-                transactionId,
-                amount
-            };
+        
+        applyTransaction({ id, data }) {
             return apiHandler.post(`invoices/${id}/transaction`, data);
         },
     };

--- a/src/resources/invoices-resource.js
+++ b/src/resources/invoices-resource.js
@@ -61,11 +61,11 @@ export default function InvoicesResource({apiHandler}) {
         },
 
         abandon({id}) {
-            return apiHandler.post(`invoices/${id}/abandon`, null);
+            return apiHandler.post(`invoices/${id}/abandon`);
         },
 
         void({id}) {
-            return apiHandler.post(`invoices/${id}/void`, null);
+            return apiHandler.post(`invoices/${id}/void`);
         },
 
         getAllInvoiceItems({id, limit = null, offset = null, expand = null}) {

--- a/src/resources/payouts-resource.js
+++ b/src/resources/payouts-resource.js
@@ -1,7 +1,7 @@
-export default function PayoutsResource({ apiHandler }) {
-    return {
-      create({ data }) {
-        return apiHandler.post(`payouts`, data);
-      },
-    };
-  }
+export default function PayoutsResource({apiHandler}) {
+  return {
+    create({data}) {
+      return apiHandler.post(`payouts`, data);
+    },
+  };
+}

--- a/src/resources/payouts-resource.js
+++ b/src/resources/payouts-resource.js
@@ -5,4 +5,3 @@ export default function PayoutsResource({ apiHandler }) {
       },
     };
   }
-  

--- a/src/resources/payouts-resource.js
+++ b/src/resources/payouts-resource.js
@@ -1,29 +1,8 @@
-export default function PayoutsResource({apiHandler}) {
+export default function PayoutsResource({ apiHandler }) {
     return {
-        create({
-                   amount = null,
-                   currency = null,
-                   websiteId = null,
-                   customerId = null,
-                   paymentInstrumentId = null,
-                   token = null,
-                   methods = null,
-                   requestId,
-                   description,
-               }) {
-            return apiHandler.post(`payouts`, {
-                amount,
-                currency,
-                websiteId,
-                customerId,
-                paymentInstruction: {
-                    paymentInstrumentId,
-                    token,
-                    methods,
-                },
-                requestId,
-                description,
-            });
-        },
+      create({ data }) {
+        return apiHandler.post(`payouts`, data);
+      },
     };
-};
+  }
+  

--- a/src/resources/subscriptions-resource.js
+++ b/src/resources/subscriptions-resource.js
@@ -59,7 +59,7 @@ export default function SubscriptionsResource({apiHandler}) {
             return apiHandler.getAll(`subscriptions/${id}/upcoming-invoices`, params);
         },
 
-        issueUpcomingInvoice({id, invoiceId, data = {}}) {
+        issueUpcomingInvoice({id, invoiceId, data}) {
             return apiHandler.post(`subscriptions/${id}/upcoming-invoices/${invoiceId}/issue`, data);
         },
 

--- a/src/resources/tags-resource.js
+++ b/src/resources/tags-resource.js
@@ -1,4 +1,4 @@
-export default function TagsResource({ apiHandler }) {
+export default function TagsResource({apiHandler}) {
   return {
     getAll({
       limit = null,
@@ -7,31 +7,31 @@ export default function TagsResource({ apiHandler }) {
       q = null,
       sort = null,
     } = {}) {
-      const params = { limit, offset, filter, q, sort };
+      const params = {limit, offset, filter, q, sort};
       return apiHandler.getAll(`tags`, params);
     },
-    create({ data }) {
+    create({data}) {
       return apiHandler.post(`tags`, data);
     },
-    get({ tag }) {
+    get({tag}) {
       return apiHandler.get(`tags/${tag}`);
     },
-    delete({ tag }) {
+    delete({tag}) {
       return apiHandler.delete(`tags/${tag}`);
     },
-    update({ tag, data }) {
+    update({tag, data}) {
       return apiHandler.patch(`tags/${tag}`, data);
     },
-    tagCustomers({ tag, data }) {
+    tagCustomers({tag, data}) {
       return apiHandler.post(`tags/${tag}/customers`, data);
     },
-    untagCustomers({ tag, data }) {
+    untagCustomers({tag, data}) {
       return apiHandler.delete(`tags/${tag}/customers`, data);
     },
-    tagCustomer({ tag, customerId }) {
+    tagCustomer({tag, customerId}) {
       return apiHandler.post(`tags/${tag}/customers/${customerId}`);
     },
-    untagCustomer({ tag, customerId }) {
+    untagCustomer({tag, customerId}) {
       return apiHandler.delete(`tags/${tag}/customers/${customerId}`);
     },
   };

--- a/src/resources/tags-resource.js
+++ b/src/resources/tags-resource.js
@@ -1,58 +1,38 @@
-
-const RESOURCE = 'tags';
-
-export default function TagsResource({apiHandler}) {
-    return {
-        getAll({
-            limit = null,
-            offset = null,
-            filter = null,
-            q = null,
-            sort = null,
-        } = {}) {
-            return apiHandler.getAll(RESOURCE, {
-                limit,
-                offset,
-                filter,
-                q,
-                sort,
-            });
-        },
-
-        create({name}) {
-            return apiHandler.post(`${RESOURCE}/`, {name});
-        },
-
-        get ({tag}) {
-            return apiHandler.get(`${RESOURCE}/${tag}`);
-        },
-
-        /**
-         * @param tag {String} The tag name
-         * @param name {String} New unique tag name
-         */
-        update ({tag, name}) {
-            return apiHandler.patch(`${RESOURCE}/${tag}`, {name});
-        },
-
-        delete ({tag}) {
-            return apiHandler.delete(`${RESOURCE}/${tag}`);
-        },
-
-        tagCustomers ({tag, ids}) {
-            return apiHandler.post(`${RESOURCE}/${tag}/customers`, {customerIds: ids});
-        },
-
-        tagCustomer ({tag, id}) {
-            return apiHandler.post(`${RESOURCE}/${tag}/customers/${id}`);
-        },
-
-        untagCustomers ({tag, ids}) {
-            return apiHandler.deleteAll(`${RESOURCE}/${tag}/customers`, {customerIds: ids});
-        },
-
-        untagCustomer ({tag, id}) {
-            return apiHandler.delete(`${RESOURCE}/${tag}/customers/${id}`);
-        },
-    };
-};
+export default function TagsResource({ apiHandler }) {
+  return {
+    getAll({
+      limit = null,
+      offset = null,
+      filter = null,
+      q = null,
+      sort = null,
+    } = {}) {
+      const params = { limit, offset, filter, q, sort };
+      return apiHandler.getAll(`tags`, params);
+    },
+    create({ data }) {
+      return apiHandler.post(`tags`, data);
+    },
+    get({ tag }) {
+      return apiHandler.get(`tags/${tag}`);
+    },
+    delete({ tag }) {
+      return apiHandler.delete(`tags/${tag}`);
+    },
+    update({ tag, data }) {
+      return apiHandler.patch(`tags/${tag}`, data);
+    },
+    tagCustomers({ tag, data }) {
+      return apiHandler.post(`tags/${tag}/customers`, data);
+    },
+    untagCustomers({ tag, data }) {
+      return apiHandler.delete(`tags/${tag}/customers`, data);
+    },
+    tagCustomer({ tag, customerId }) {
+      return apiHandler.post(`tags/${tag}/customers/${customerId}`);
+    },
+    untagCustomer({ tag, customerId }) {
+      return apiHandler.delete(`tags/${tag}/customers/${customerId}`);
+    },
+  };
+}


### PR DESCRIPTION
In the vast majority of our resource functions we use a data parameter in order to pass our `request payloads`.

However, we have some functions that are not following that behavior as we are explicitly using the request structure. These functions are:
- Some `tag-resource` functions
- `applyTransaction` function in` invoice-resource`
- `create` function in `payouts-resource`
 
This PR modifies the previous functions to use the more consistent data parameter instead. 

We are also removing unnecessary `null data `parameter in `void` and `abandon` functions to match the auto generated standardized code. 

