### PR TITLE
Bug fix: Use correct apiHandler function for GetDraftRuleset endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "31.1.0",
+  "version": "31.1.1",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/src/resources/events-resource.js
+++ b/src/resources/events-resource.js
@@ -50,7 +50,7 @@ export default function EventsResource({apiHandler}) {
         },
 
         getDraftRuleset({eventType = null, id = null} = {}) {
-            return apiHandler.getAll(`events/${eventType}/rules/drafts/${id}`);
+            return apiHandler.get(`events/${eventType}/rules/drafts/${id}`);
         },
 
         createDraftRuleset({eventType = null, data = {}} = {}) {


### PR DESCRIPTION
## Details
* `getDraftRuleset` endpoint released with incorrect handler function