### PR TITLE
Expose billing portal resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebilly-js-sdk",
-  "version": "37.0.0",
+  "version": "38.0.0",
   "description": "Official Rebilly API JS library for the browser and Node",
   "browser": "./dist/rebilly-js-sdk.js",
   "main": "./dist/rebilly-js-sdk.node.js",

--- a/src/create-api-instance.js
+++ b/src/create-api-instance.js
@@ -8,6 +8,7 @@ export class ApiInstance {
         this.aml = Resources.AmlResource({apiHandler})
         this.apiKeys = Resources.ApiKeysResource({apiHandler})
         this.bankAccounts = Resources.BankAccountsResource({apiHandler}),
+        this.billingPortals = Resources.BillingPortalsResource({apiHandler}),
         this.blocklists = Resources.BlocklistsResource({apiHandler}),
         this.gatewayAccounts = Resources.GatewayAccountsResource({apiHandler})
         this.broadcastMessages = Resources.BroadcastMessagesResource({apiHandler}),

--- a/src/create-api-instance.js
+++ b/src/create-api-instance.js
@@ -115,6 +115,7 @@ export class StorefrontApiInstance {
     constructor({apiHandler}) {
         this.account = StorefrontResources.AccountResource({apiHandler}),
         this.authorization = StorefrontResources.AuthorizationResource({apiHandler}),
+        this.billingPortal = StorefrontResources.BillingPortalResource({apiHandler}),
         this.checkoutForm = StorefrontResources.CheckoutFormResource({apiHandler}),
         this.invoices = StorefrontResources.InvoicesResource({apiHandler}),
         this.kycDocuments = StorefrontResources.KycDocumentsResource({apiHandler}),

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -2,6 +2,7 @@ import AccountResource from './account-resource';
 import AmlResource from './aml-resource';
 import ApiKeysResource from './api-keys-resource';
 import BankAccountsResource from './bank-accounts-resource';
+import BillingPortalsResource from './billing-portals-resource';
 import BlocklistsResource from './blocklists-resource';
 import BroadcastMessagesResource from './broadcast-messages-resource';
 import CheckoutFormsResource from './checkout-forms-resource';
@@ -58,6 +59,7 @@ const Resources = {
     AmlResource,
     ApiKeysResource,
     BankAccountsResource,
+    BillingPortalsResource,
     BlocklistsResource,
     BroadcastMessagesResource,
     CheckoutFormsResource,

--- a/src/resources/storefront/index.js
+++ b/src/resources/storefront/index.js
@@ -1,5 +1,6 @@
 import AccountResource from './account-resource';
 import AuthorizationResource from './authorization-resource';
+import BillingPortalResource from './billing-portals-resource';
 import CheckoutFormResource from './checkout-forms-resource';
 import InvoicesResource from './invoices-resource';
 import KycDocumentsResource from './kyc-documents-resource';
@@ -13,6 +14,7 @@ import WebsitesResource from './websites-resource';
 const StorefrontResources = {
   AccountResource,
   AuthorizationResource,
+  BillingPortalResource,
   CheckoutFormResource,
   InvoicesResource,
   KycDocumentsResource,


### PR DESCRIPTION
Follow up to #304 to expose the billing portal resources on the api instance. 

I've build this locally and I am able to use it successfully.