### PR TITLE
Fix type generation for put functions containing schema references

### DIFF
--- a/scripts/type-generation/generate-sdk-types.js
+++ b/scripts/type-generation/generate-sdk-types.js
@@ -157,6 +157,10 @@ function generateSdkTypes(schema, verbose = false) {
     ) {
       result += `['content']['application/json']`;
     }
+    // Assuming that $ref will always contain application/json
+    if (code === '201' && path.responses[code]['$ref']) {
+      result += `['content']['application/json']`;
+    }
     return result;
   }
 

--- a/test/unit/specs/generate-sdk-types.spec.js
+++ b/test/unit/specs/generate-sdk-types.spec.js
@@ -13,7 +13,7 @@ const responses = {
   403: {},
 };
 
-it('Generates TS type for collection getAll', async () => {
+it('Generates TS type for collection getAll response', async () => {
   const schema = {
     paths: {
       '/customers': {
@@ -31,7 +31,7 @@ it('Generates TS type for collection getAll', async () => {
   );
 });
 
-it('Generates TS type for collection getAll in storefront schema', async () => {
+it('Generates TS type for collection getAll response in storefront schema', async () => {
   const schema = {
     paths: {
       '/transactions': {
@@ -46,5 +46,47 @@ it('Generates TS type for collection getAll in storefront schema', async () => {
   const types = generateSdkTypes(schema).trim();
   expect(types).to.eql(
     `type StorefrontGetTransactionCollectionResponse = Promise<{ items: operations['StorefrontGetTransactionCollection']['responses']['200']['content']['application/json']}>`
+  );
+});
+
+it('Generates TS type for resource get response', async () => {
+  const schema = {
+    paths: {
+      '/customers/{id}': {
+        get: {
+          operationId: 'GetCustomer',
+          responses,
+        },
+      },
+    },
+  };
+
+  const types = generateSdkTypes(schema).trim();
+  expect(types).to.eql(
+    `type GetCustomerResponse = Promise<{fields: operations['GetCustomer']['responses']['200']['content']['application/json']}>`
+  );
+});
+
+it('Generates TS type for resource put response', async () => {
+  const putResponses = {
+    ...responses,
+    ...{
+      201: { $ref: '#/components/responses/Customer' },
+    },
+  };
+  const schema = {
+    paths: {
+      '/customers/{id}': {
+        put: {
+          operationId: 'PutCustomer',
+          responses: putResponses,
+        },
+      },
+    },
+  };
+
+  const types = generateSdkTypes(schema).trim();
+  expect(types).to.eql(
+    `type PutCustomerResponse = Promise<{fields: operations['PutCustomer']['responses']['201']['content']['application/json']}>`
   );
 });


### PR DESCRIPTION
This PR fixes typescript type generation for likes like: 

` type PutCustomerResponse = Promise<{fields: operations['PutCustomer']['responses']['201']['content']['application/json']}>
`
whose responses schema point to another schema through a `$ref`