### PR TITLE
Fix dead link

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,4 +2,4 @@ This documentation has moved.
 
 Installation and usage instructions can be found in the new [Rebilly Docs](https://docs.rebilly.com/docs/developer-docs/sdks).
 
-Code samples are now directly available in the [Rebilly API definitions](https://docs.rebilly.com/docs/developer-docs/api/overview/).
+Code samples are now directly available in the [Rebilly API definitions](https://www.rebilly.com/docs/content/dev-docs/api/overview/).


### PR DESCRIPTION
## Details

Link for Rebilly API definitions was broken on [github page](https://rebilly.github.io/rebilly-js-sdk/)