### PR TITLE
fix: Use machine user PAT for git commands

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.MACHINE_USER_PAT }}
       - uses: actions/setup-node@v1
         with:
           node-version: 12


### PR DESCRIPTION
### Currently

The release process fails, because branch protection rules are enabled on this repo, and the default GITHUB_TOKEN used during GHA cannot push without satisfying these rules.

Failed publish run:
https://github.com/Rebilly/rebilly-js-sdk/actions/runs/1412998749

```
remote: error: GH006: Protected branch update failed for refs/heads/main.        
```

### Changes

This PR uses the rebilly machine user PAT which has admin access, and should be able to push the release commit to main.

I've tested this in a separate repo: 
failing without admin token: https://github.com/Weetbix/release-automation-example/runs/4082480131?check_suite_focus=true
passing with admin token: https://github.com/Weetbix/release-automation-example/actions/runs/1416112920


### Links
https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101
