### PR TITLE
 Replace organizationId header with prefix

### DIFF
--- a/src/create-api-handler.js
+++ b/src/create-api-handler.js
@@ -71,8 +71,14 @@ export default function createApiHandler({options}) {
      * @returns {string}
      */
     function getBaseURL() {
-        const url = options.isSandbox ? options.apiEndpoints.sandbox : options.apiEndpoints.live;
-        return `${url}/${options.apiVersion || ''}`;
+        let url = options.isSandbox ? options.apiEndpoints.sandbox : options.apiEndpoints.live;
+        if (options.apiVersion) {
+            url = `${url}/${options.apiVersion}`;
+        }
+        if (options.organizationId) {
+            url = `${url}/organizations/${options.organizationId}`;
+        }
+        return `${url}`;
     }
 
     /**
@@ -85,9 +91,6 @@ export default function createApiHandler({options}) {
         };
         if (options.apiKey) {
             headers['REB-APIKEY'] = options.apiKey;
-        }
-        if (options.organizationId) {
-            headers['Organization-Id'] = options.organizationId;
         }
         return headers;
     }

--- a/test/unit/specs/api-handler-new.spec.js
+++ b/test/unit/specs/api-handler-new.spec.js
@@ -1,5 +1,5 @@
-import createApiHandler from '../../../src/create-api-handler';
 import createApiInstance from '../../../src/create-api-instance';
+import createApiTestHandler from "../create-api-test-handler";
 
 describe('when I use an API handler', () => {
     const options = {
@@ -10,20 +10,19 @@ describe('when I use an API handler', () => {
         requestTimeout: 1,
         jwt: null
     };
-    const apiHandler = createApiHandler({options});
+    const apiHandler = createApiTestHandler({options});
     const api = createApiInstance({apiHandler});
-
 
     it('Ignores get params when they are null', async () => {
         const instance = apiHandler.getInstance();
-        instance.get = jest.fn();
+        instance.get = jest.fn().mockImplementation(instance.get);
 
-        api.aml.getAll({firstName: 'Kiko', lastName: 'Rivera', dob: null});
+        api.customers.getAll({limit: null, filter: 'firstName:Kiko', q: 'Rivera'});
 
         expect(instance.get).toHaveBeenCalledTimes(1);
-        expect(instance.get).toHaveBeenCalledWith('aml', {
+        expect(instance.get).toHaveBeenCalledWith('customers', {
             cancelToken: expect.anything(),
-            params: { firstName: "Kiko", lastName: "Rivera" }
-        }); 
+            params: {filter: 'firstName:Kiko', q: 'Rivera'}
+        });
     });
 });

--- a/test/unit/specs/api-handler-new.spec.js
+++ b/test/unit/specs/api-handler-new.spec.js
@@ -1,5 +1,5 @@
 import createApiInstance from '../../../src/create-api-instance';
-import createApiTestHandler from "../create-api-test-handler";
+import createApiTestHandler from '../create-api-test-handler';
 
 describe('when I use an API handler', () => {
     const options = {

--- a/test/unit/specs/api-handler.spec.js
+++ b/test/unit/specs/api-handler.spec.js
@@ -30,7 +30,7 @@ describe('when I use an API handler', () => {
         expect(options.jwt).toBe(token);
     });
 
-    it('should have Organization-Id header if set it up', () => {
+    it('should have organization prefix if set it up', () => {
         const options = {
             version: 1,
             apiEndpoints: {live: '', sandbox: ''},
@@ -41,11 +41,11 @@ describe('when I use an API handler', () => {
             organizationId: 'org-id-123'
         };
         const handler = createApiTestHandler({options});
-        expect(handler.getInstance().defaults.headers['Organization-Id']).toBe('org-id-123');
+        expect(handler.getInstance().defaults.baseURL).toContain('/organizations/org-id-123');
     });
 
-    it('should not have Organization-Id header if it not set', () => {
-        expect(apiHandler.getInstance().defaults.headers['Organization-Id']).toBeUndefined();
+    it('should not have organization prefix header if it not set', () => {
+        expect(apiHandler.getInstance().defaults.baseURL).not.toContain('/organizations/');
     });
 
     it('should allow the proxy agent to be set', () => {
@@ -56,7 +56,7 @@ describe('when I use an API handler', () => {
 
     it('should allow the endpoints to be set', () => {
         apiHandler.setEndpoints({live: 'live-endpoint.rebilly.com', sandbox: 'sandbox-endpoint.rebilly.com'});
-        expect(apiHandler.getInstance().defaults.baseURL).toBe('live-endpoint.rebilly.com/');
+        expect(apiHandler.getInstance().defaults.baseURL).toBe('live-endpoint.rebilly.com');
         options.apiVersion = 'experimental';
         options.isSandbox = true;
         apiHandler.setEndpoints({live: 'live-endpoint.rebilly.com', sandbox: 'sandbox-endpoint.rebilly.com'});


### PR DESCRIPTION
Related to https://github.com/Rebilly/api-definitions/pull/642

Also fixes `api-handler-new.spec.js` as it was throwing unhandled exceptions.