### PR TITLE
Reorder organization prefix and api version in base url

### DIFF
--- a/src/create-api-handler.js
+++ b/src/create-api-handler.js
@@ -72,11 +72,11 @@ export default function createApiHandler({options}) {
      */
     function getBaseURL() {
         let url = options.isSandbox ? options.apiEndpoints.sandbox : options.apiEndpoints.live;
-        if (options.apiVersion) {
-            url = `${url}/${options.apiVersion}`;
-        }
         if (options.organizationId) {
             url = `${url}/organizations/${options.organizationId}`;
+        }
+        if (options.apiVersion) {
+            url = `${url}/${options.apiVersion}`;
         }
         return `${url}`;
     }


### PR DESCRIPTION
Previously it generated `/experimental/organizations/{organizationId}/location` which is not correct, and now it's `/organizations/{organizationId}/experimental/location`