### PR TITLE
feat!: Use a global library name without hyphens

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = (env = {}) => {
             output: {
                 path: path.resolve(__dirname, './dist'),
                 filename: entry.filename,
-                library: 'rebilly-js-sdk',
+                library: 'RebillyJsSdk',
                 libraryTarget: 'umd',
                 umdNamedDefine: true
             },


### PR DESCRIPTION
### Currently

The [library property](https://webpack.js.org/configuration/output/#outputlibrary) is set to `rebilly-js-sdk`, this means when importing the library bundle directly in a browser, the SDK is exposed on the window object as `window["rebilly-js-sdk"]`. 

Due to the hyphens, the global `rebilly-js-sdk` is not accessible unless you reference it through `window["rebilly-js-sdk"]`.

For example:
```html
<script src="path/to/rebilly/sdk"></script>
<script>
  window['rebilly-js-sdk'].RebillyStorefrontAPI();
</script>
```

### After this PR

The library is exposed with a variable name that can be accessed directly:

```html
<script src="path/to/rebilly/sdk"></script>
<script>
  RebillyJsSdk.RebillyStorefrontAPI();
</script>
```

### Considerations

This library name property affects only the amd bundle by changing the exposed global, it does not affect commonjs/node so importing the library as described in the README does not change.

I tried to expose both `rebilly-js-sdk` and `RebillyJsSdk` with the webpack config to provide some backwards compatibility in case anyone is using it as a script but I wasn't able to.

In our [docs](https://www.rebilly.com/docs/content/dev-docs/concept/sdks/) we have not included instructions for including the js sdk as a script on a webpage, so I hope this change can be made without worrying about providing backwards compatibility.
