### PR TITLE
fix: Fix release action, use node 14

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ jobs:
           token: ${{ secrets.MACHINE_USER_PAT }}
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - run: yarn install --frozen-lockfile
       # Setup git credentials used for committing to the Github Actions user


### PR DESCRIPTION
Currently our release action uses node 12, which fails due to an incompatibility with vite:

https://github.com/Rebilly/rebilly-js-sdk/runs/6258017185?check_suite_focus=true

This PR changes it to 14, same as the PR tests.